### PR TITLE
Update HeartbeatManager.php

### DIFF
--- a/src/HeartbeatManager.php
+++ b/src/HeartbeatManager.php
@@ -81,7 +81,7 @@ class HeartbeatManager extends Manager
     /**
      * @return \Illuminate\Contracts\Container\Container
      */
-    protected function getContainer(): Container
+    public function getContainer(): Container
     {
         return $this->container ?? $this->app;
     }


### PR DESCRIPTION
match Laravel's `Manager` visibility for `getContainer()`

# Description

Laravel 8.35.1 introduced its own `getContainer()` method on the `Manager` class, which has `public` visibility. See: https://github.com/laravel/framework/commit/90fbaa7ec53410508cd73c09e3f788e458dd8b92#diff-89f61ad45c8a89f560679fda808f4ee93a84311e9296703e30a6bc4286e409d7

This conflicts with the visibility of `protected` that is defined for this method in this package.

Fixes #10 

## Type of change

- [ x ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Servers that were experiencing this error were tested manually. Upon retrying the Heartbeat jobs with this fix in place, they succeeded.

**Test Configuration**:
Laravel v8.35.1, running on Debian OS

# Checklist:

- [ x ] My code follows the style guidelines of this project
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I have made corresponding changes to the documentation
- [ x ] My changes generate no new warnings

No tests were added as I do not think any are necessary for this small of a fix.