### PR TITLE
Maintenance/support php 81

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,15 +10,11 @@ jobs:
       fail-fast: true
       matrix:
         php: [7.3, 7.4, 8.0]
-        laravel: [6.*, 7.*, 8.*]
+        laravel: [8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
             testbench: 6.*
-          - laravel: 7.*
-            testbench: 5.*
-          - laravel: 6.*
-            testbench: 4.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,13 +12,18 @@ jobs:
         php: [7.3, 7.4, 8.0, 8.1]
         laravel: [8.*]
         dependency-version: [prefer-lowest, prefer-stable]
+        exclude:
+          - php: 8.1
+            laravel: 8.*
+            dependency-version: prefer-lowest
         include:
           - laravel: 8.*
             testbench: 6.*
-        exclude:
-          - php : 8.1
-            laravel: 8.*
+          #Testing php 8.1 with Laravel 8.74 as its lowest
+          - php: 8.1
+            laravel: ^8.74
             dependency-version: prefer-lowest
+            testbench: 6.*
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,12 +9,16 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        php: [7.3, 7.4, 8.0]
+        php: [7.3, 7.4, 8.0, 8.1]
         laravel: [8.*]
         dependency-version: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
             testbench: 6.*
+        exclude:
+          - php : 8.1
+            laravel: 8.*
+            dependency-version: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }}
 

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
     ],
     "require": {
         "php": "^7.3|^8.0",
-        "laravel/framework": "^6.0|^7.0|^8.0"
+        "laravel/framework": "^8.0"
     },
     "require-dev": {
         "guzzlehttp/guzzle": "^6.3",
         "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^4.0|^5.0|^6.0",
+        "orchestra/testbench": "^6.0",
         "phpunit/phpunit": "^9.3.3",
         "squizlabs/php_codesniffer": "^3.6"
     },


### PR DESCRIPTION
Dropped support for laravel 6 and 7 : [#34493](https://redmine.exolnet.com/issues/34493)
Tested support for php 8.1 : [#34480](https://redmine.exolnet.com/issues/34480)